### PR TITLE
Remove filter for fetching liquidity_net.

### DIFF
--- a/lpbook/lps/uniswap_v3/subgraph.py
+++ b/lpbook/lps/uniswap_v3/subgraph.py
@@ -77,7 +77,7 @@ class UniV3GraphQLClient(GraphQLClient):
 
     def get_ticks(self, ticks_filter, **kwargs):
         """Get pool ticks."""
-        # ticks_filter.update({'liquidity_net_gt': 0})
+        ticks_filter.update({'liquidity_net_not': 0})
         return self.paginated_on_id(partial(self.get_ticks_page, ticks_filter, **kwargs))
 
     async def get_pool_state(self, pool_id, **kwargs):

--- a/lpbook/lps/uniswap_v3/subgraph.py
+++ b/lpbook/lps/uniswap_v3/subgraph.py
@@ -77,7 +77,7 @@ class UniV3GraphQLClient(GraphQLClient):
 
     def get_ticks(self, ticks_filter, **kwargs):
         """Get pool ticks."""
-        ticks_filter.update({'liquidity_net_gt': 0})
+        # ticks_filter.update({'liquidity_net_gt': 0})
         return self.paginated_on_id(partial(self.get_ticks_page, ticks_filter, **kwargs))
 
     async def get_pool_state(self, pool_id, **kwargs):


### PR DESCRIPTION
Not sure if that filter has some unrelated purpose, but I guess we also need to fetch all ticks with negative liquidity updates.
We can exclude ticks with zero-updates though (don't know if such a filter exists :shrug:).